### PR TITLE
SIMD within a register optimizations

### DIFF
--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -390,32 +390,97 @@ fn scan_image_for_candidates(image: &GrayImage,
         let threshold = row_min.saturating_add(sigma_noise_2 as u8 / 2);
 
         // Second pass: pixel loop, only create gates when needed.
-        if compute_histogram {
-            for center_x in 3..(row_pixels.len()-3) {
-                let center_pixel = row_pixels[center_x];
-                histogram[center_pixel as usize] += 1;
-                if center_pixel >= threshold {
-                    let gate = &row_pixels[center_x-3..center_x+4];
-                    let result_type = gate_star_1d(
-                        gate, sigma_noise_2, sigma_noise_3);
-                    if result_type == ResultType::Candidate {
-                        candidates.push(CandidateFrom1D{x: center_x as i32,
-                                                        y: rownum as i32});
+        let end_x = row_pixels.len().saturating_sub(3);
+        if end_x > 3 {
+            let inner_pixels = &row_pixels[3..end_x];
+            let mut center_x = 3;
+            
+            let mut chunks = inner_pixels.chunks_exact(8);
+            let t16 = (threshold as u64) * 0x0001000100010001;
+
+            if compute_histogram {
+                for chunk in chunks.by_ref() {
+                    for &p in chunk {
+                        histogram[p as usize] += 1;
+                    }
+                    
+                    let w = u64::from_ne_bytes(chunk.try_into().unwrap());
+                    let w_even = (w & 0x00FF00FF00FF00FF) | 0x0100010001000100;
+                    let w_odd = ((w >> 8) & 0x00FF00FF00FF00FF) | 0x0100010001000100;
+                    
+                    let diff_even = w_even.wrapping_sub(t16);
+                    let diff_odd = w_odd.wrapping_sub(t16);
+                    
+                    if (diff_even | diff_odd) & 0x0100010001000100 != 0 {
+                        for &center_pixel in chunk {
+                            if center_pixel >= threshold {
+                                let gate = &row_pixels[center_x-3..center_x+4];
+                                let result_type = gate_star_1d(
+                                    gate, sigma_noise_2, sigma_noise_3);
+                                if result_type == ResultType::Candidate {
+                                    candidates.push(CandidateFrom1D{x: center_x as i32,
+                                                                    y: rownum as i32});
+                                }
+                            }
+                            center_x += 1;
+                        }
+                    } else {
+                        center_x += 8;
                     }
                 }
-            }
-        } else {
-            // Identical except omits histogram update.
-            for center_x in 3..(row_pixels.len()-3) {
-                let center_pixel = row_pixels[center_x];
-                if center_pixel >= threshold {
-                    let gate = &row_pixels[center_x-3..center_x+4];
-                    let result_type = gate_star_1d(
-                        gate, sigma_noise_2, sigma_noise_3);
-                    if result_type == ResultType::Candidate {
-                        candidates.push(CandidateFrom1D{x: center_x as i32,
-                                                        y: rownum as i32});
+                
+                for &center_pixel in chunks.remainder() {
+                    histogram[center_pixel as usize] += 1;
+                    if center_pixel >= threshold {
+                        let gate = &row_pixels[center_x-3..center_x+4];
+                        let result_type = gate_star_1d(
+                            gate, sigma_noise_2, sigma_noise_3);
+                        if result_type == ResultType::Candidate {
+                            candidates.push(CandidateFrom1D{x: center_x as i32,
+                                                            y: rownum as i32});
+                        }
                     }
+                    center_x += 1;
+                }
+            } else {
+                // Identical except omits histogram update.
+                for chunk in chunks.by_ref() {
+                    let w = u64::from_ne_bytes(chunk.try_into().unwrap());
+                    let w_even = (w & 0x00FF00FF00FF00FF) | 0x0100010001000100;
+                    let w_odd = ((w >> 8) & 0x00FF00FF00FF00FF) | 0x0100010001000100;
+                    
+                    let diff_even = w_even.wrapping_sub(t16);
+                    let diff_odd = w_odd.wrapping_sub(t16);
+                    
+                    if (diff_even | diff_odd) & 0x0100010001000100 != 0 {
+                        for &center_pixel in chunk {
+                            if center_pixel >= threshold {
+                                let gate = &row_pixels[center_x-3..center_x+4];
+                                let result_type = gate_star_1d(
+                                    gate, sigma_noise_2, sigma_noise_3);
+                                if result_type == ResultType::Candidate {
+                                    candidates.push(CandidateFrom1D{x: center_x as i32,
+                                                                    y: rownum as i32});
+                                }
+                            }
+                            center_x += 1;
+                        }
+                    } else {
+                        center_x += 8;
+                    }
+                }
+                
+                for &center_pixel in chunks.remainder() {
+                    if center_pixel >= threshold {
+                        let gate = &row_pixels[center_x-3..center_x+4];
+                        let result_type = gate_star_1d(
+                            gate, sigma_noise_2, sigma_noise_3);
+                        if result_type == ResultType::Candidate {
+                            candidates.push(CandidateFrom1D{x: center_x as i32,
+                                                            y: rownum as i32});
+                        }
+                    }
+                    center_x += 1;
                 }
             }
         }

--- a/src/image_funcs.rs
+++ b/src/image_funcs.rs
@@ -50,16 +50,61 @@ fn bin_and_histogram_2x2_default(image: &GrayImage, normalize_rows: bool)
     let source_pixels = source_image.as_raw();
 
     for y in (0..height & !1).step_by(2) {  // Ensure even height bound
-        for x in (0..width & !1).step_by(2) {   // Ensure even width bound
-            // Get 2x2 block.
-            let p1 = source_pixels[(y * width + x) as usize] as u16;
-            let p2 = source_pixels[(y * width + x + 1) as usize] as u16;
-            let p3 = source_pixels[((y + 1) * width + x) as usize] as u16;
-            let p4 = source_pixels[((y + 1) * width + x + 1) as usize] as u16;
-
-            // Average the 2x2 block.
+        let row1_start = (y * width) as usize;
+        let row2_start = ((y + 1) * width) as usize;
+        
+        let row1_pixels = &source_pixels[row1_start..row1_start + (width as usize & !1)];
+        let row2_pixels = &source_pixels[row2_start..row2_start + (width as usize & !1)];
+        
+        let mut chunks1 = row1_pixels.chunks_exact(8);
+        let mut chunks2 = row2_pixels.chunks_exact(8);
+        
+        for (chunk1, chunk2) in chunks1.by_ref().zip(chunks2.by_ref()) {
+            let w1 = u64::from_ne_bytes(chunk1.try_into().unwrap());
+            let w2 = u64::from_ne_bytes(chunk2.try_into().unwrap());
+            
+            // Mask out odd bytes to sum even bytes: (p0, p2, p4, p6)
+            let even1 = w1 & 0x00FF00FF00FF00FF;
+            let even2 = w2 & 0x00FF00FF00FF00FF;
+            
+            // Shift down odd bytes to sum them: (p1, p3, p5, p7)
+            let odd1 = (w1 >> 8) & 0x00FF00FF00FF00FF;
+            let odd2 = (w2 >> 8) & 0x00FF00FF00FF00FF;
+            
+            // Sum horizontally within each row: (p0+p1, p2+p3, p4+p5, p6+p7)
+            let sum1 = even1 + odd1;
+            let sum2 = even2 + odd2;
+            
+            // Sum vertically across rows and divide by 4 (shift right by 2)
+            // (p0+p1+p0'+p1')/4, (p2+p3+p2'+p3')/4, etc.
+            let avg = (sum1 + sum2) >> 2;
+            
+            // Extract the 4 average bytes back out
+            // Since they are spaced every 16 bits, we can just mask and pack
+            let avg_bytes = [
+                (avg & 0xFF) as u8,
+                ((avg >> 16) & 0xFF) as u8,
+                ((avg >> 32) & 0xFF) as u8,
+                ((avg >> 48) & 0xFF) as u8,
+            ];
+            
+            resized_image.extend_from_slice(&avg_bytes);
+            
+            // Histogram update must remain scalar
+            histogram[avg_bytes[0] as usize] += 1;
+            histogram[avg_bytes[1] as usize] += 1;
+            histogram[avg_bytes[2] as usize] += 1;
+            histogram[avg_bytes[3] as usize] += 1;
+        }
+        
+        // Handle remainder for widths not divisible by 8 (but divisible by 2)
+        for (chunk1, chunk2) in chunks1.remainder().chunks_exact(2).zip(chunks2.remainder().chunks_exact(2)) {
+            let p1 = chunk1[0] as u16;
+            let p2 = chunk1[1] as u16;
+            let p3 = chunk2[0] as u16;
+            let p4 = chunk2[1] as u16;
+            
             let avg = ((p1 + p2 + p3 + p4) / 4) as u8;
-
             resized_image.push(avg);
             histogram[avg as usize] += 1;
         }


### PR DESCRIPTION
These changes use SWAR techniques to eke out more performance, targeted to the Raspberry Pi platform. Although the benchmark tests show almost ~2x improvement in the star extraction, the real-world performance delta on an RPIZ2W seems to be only 7-10%. So this might be an optimization to pass on.

Original change description:

Optimize threshold scanning and 2x2 binning with SWAR
Replaces scalar pixel loops with SIMD Within A Register (SWAR) logic to
process 8 bytes at a time in parallel using 64-bit integer registers.

- `scan_image_for_candidates`: Uses a bitwise subtraction trick with a
   carry-stop bit to evaluate 8 pixels simultaneously for fast threshold
   skipping.
- `bin_and_histogram_2x2_default`: Loads two 8-byte row segments and
   uses bitwise splits and shifts to safely calculate four 16-bit
   averages simultaneously.

Bypasses LLVM auto-vectorization heuristics to guarantee performance
improvements on Cortex-A53 without requiring explicit aarch64 intrinsics
or unsafe blocks.

Performance improvement of nearly 2x on an RPI5.